### PR TITLE
Remove unneeded venv creation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,5 +2,4 @@
 
 set -x
 
-python -m venv venv
 pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
It is not necessary to create a virtual environment because workflow scripts run in isolated containers.